### PR TITLE
Add volume and mute control via UPnP RenderingControl

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,21 @@ can be deactivated with value "0"
 ### 2.7. Command Delay
 delay in milliseconds between the commands sent via the iobroker.samsung_tizen.0.control.sendCmd object. 
 
+### 2.8. Volume control via UPnP
+Adds the objects iobroker.samsung_tizen.0.media.volume and iobroker.samsung_tizen.0.media.mute,
+which report the current TV volume and can also set it directly.
+
+This uses the UPnP RenderingControl service on port 9197 instead of the WebSocket remote control
+channel, so it can read the volume level and set an absolute value, which the KEY_VOLUP and
+KEY_VOLDOWN keys cannot do. No pairing token is needed.
+
+The TV only answers this service for clients on its own subnet. If ioBroker reaches the TV through
+a router, from a different subnet or VLAN, the TV replies "401 Unauthorized" and the volume can
+neither be read nor set. The service is also only reachable while the TV is switched on, so the
+values are not updated in standby.
+
+Disabled by default, as not every model provides the service.
+
 ## 3. Usage
 
 ### 3.1. Control
@@ -160,6 +175,13 @@ There are few example commands but you can also create your own macros.
 </p>
 </details>
 
+### 3.4. Volume and mute
+read the current volume from iobroker.samsung_tizen.0.media.volume, or write a value between
+0 and 100 to it to set the volume directly. iobroker.samsung_tizen.0.media.mute reports and sets
+the mute state. Both are updated on every polling interval while the TV is on.
+
+Requires "volume control via UPnP" to be enabled in the instance configuration.
+
 ## Credits
 
 The first generation of this adapter has been developed by Stefan0875 (https://github.com/Stefan0875) which has been adapted and maintined by highpressure (https://github.com/Highpressure) and finaly dahuby (https://github.com/dahuby). Thanks a lot for their work and grantig a publich license.
@@ -172,6 +194,7 @@ The first generation of this adapter has been developed by Stefan0875 (https://g
 -->
 
 ### **WORK IN PROGRESS**
+- (AlanSRU) Added volume and mute control via the UPnP RenderingControl service, disabled by default
 - (copilot) Adapter requires node.js >= 22 now
 - (iobroker-bot) Adapter requires node.js >= 20 now.
 - (copilot) Adapter requires admin >= 7.7.22 now

--- a/admin/index.html
+++ b/admin/index.html
@@ -21,6 +21,7 @@
 	    "pollingPort":                    {"en": "polling port", "de": "Polling Port"},
 	    "pollingInterval":                    {"en": "polling interval", "de": "Polling Intervall"},
         "macAddress":                    {"en": "mac address", "de": "MAC Adresse"},
+        "useUPnPVolume":               {"en": "volume control via UPnP", "de": "Lautstärkeregelung über UPnP"},
         "cmdDelay":                    {"en": "command delay", "de": "Command Verzögerung"},
         "on save adapter restarts with new config immediately": {
             "de": "Beim Speichern der Einstellungen wird der Adapter sofort neu gestartet.",
@@ -48,7 +49,11 @@ function save(callback) {
         var obj = {};
         $('.value').each(function () {
             var $this = $(this);
-            obj[$this.attr('id')] = $this.val();
+            if ($this.attr('type') === 'checkbox') {
+                obj[$this.attr('id')] = $this.prop('checked');
+            } else {
+                obj[$this.attr('id')] = $this.val();
+            }
         });
         callback(obj);
     }
@@ -69,6 +74,7 @@ function save(callback) {
         <span class="translate">pollingPort</span> <input class="value" id="pollingPort"/><br>
         <span class="translate">pollingInterval</span> <input class="value" id="pollingInterval"/>in s <span class="translate">(0 to deactivate)</span><br>
         <span class="translate">cmdDelay</span> <input class="value" id="cmdDelay"/>in ms<br>
+        <span class="translate">useUPnPVolume</span> <input class="value" id="useUPnPVolume" type="checkbox"/><br>
     </p>
         <p class="translate">on save adapter restarts with new config immediately</p>
 </div>

--- a/io-package.json
+++ b/io-package.json
@@ -140,7 +140,8 @@
     "macAddress": "ab:12:cd:34:ef:56",
     "cmdDelay": "1000",
     "pollingPort": "9110",
-    "pollingInterval": "60"
+    "pollingInterval": "60",
+    "useUPnPVolume": false
   },
   "objects": []
 }

--- a/main.js
+++ b/main.js
@@ -6,8 +6,17 @@ const adapter = utils.adapter('samsung_tizen');
 const isPortReachable = require('is-port-reachable');
 const wol = require('wake_on_lan');
 const WebSocket = require('ws');
+const http = require('node:http');
 
 let ws;
+
+// UPnP RenderingControl service, used for volume and mute.
+// The port is fixed: these TVs do not answer SSDP discovery, and 9197 only
+// listens while the TV is switched on.
+const UPNP_PORT = 9197;
+const UPNP_PATH = '/upnp/control/RenderingControl1';
+const UPNP_SERVICE = 'urn:schemas-upnp-org:service:RenderingControl:1';
+const UPNP_MASTER = '<InstanceID>0</InstanceID><Channel>Master</Channel>';
 
 adapter.on('stateChange', function (id, state) {
     const key = id.split('.');
@@ -30,6 +39,11 @@ adapter.on('stateChange', function (id, state) {
     if (key[2] === 'config' && key[3] === 'getToken'){
         getToken();
     } 
+    if (key[2] === 'media' && state && !state.ack){
+        if (key[3] === 'volume'){ setVolume(state.val); }
+        if (key[3] === 'mute'){ setMute(state.val); }
+        return;
+    }
     if (key[3].toUpperCase() === 'SENDCMD'){
         sendCmd(state.val.split(','), 0);
     }
@@ -64,11 +78,16 @@ function main() {
         },
         native: {}
     });
+    if (adapter.config.useUPnPVolume){createVolumeStates();}
     if (parseFloat(adapter.config.pollingInterval) > 0){getPowerOnState();};
     adapter.subscribeStates('control.*');
     adapter.subscribeStates('apps.*');
     adapter.subscribeStates('command.*');
     adapter.subscribeStates('config.*');
+    if (adapter.config.useUPnPVolume){
+        adapter.subscribeStates('media.*');
+        updateVolumeStates();
+    }
     adapter.log.info(adapter.name + '.' + adapter.instance + ' started with config : ' + JSON.stringify(adapter.config));
 }
 function getPowerOnState(){
@@ -87,6 +106,8 @@ function getPowerOnState(){
             adapter.setState('powerOn', response, true, function (err) {
                 if (err) adapter.log.error(err);
             });
+            // port 9197 is closed while the TV is in standby
+            if (response && adapter.config.useUPnPVolume){ await updateVolumeStates(); }
         })();
 
     }, parseFloat(adapter.config.pollingInterval) * 1000)
@@ -307,4 +328,119 @@ async function getPowerStateInstant(){
             });
             return response
         
+}
+
+function createVolumeStates() {
+    adapter.setObject('media', {
+        type: 'channel',
+        common: {
+            name: 'volume and mute'
+        },
+        native: {}
+    });
+    adapter.setObject('media.volume', {
+        type: 'state',
+        common: {
+            name: 'volume level',
+            type: 'number',
+            role: 'level.volume',
+            min: 0,
+            max: 100,
+            def: 0,
+            read: true,
+            write: true
+        },
+        native: {}
+    });
+    adapter.setObject('media.mute', {
+        type: 'state',
+        common: {
+            name: 'mute',
+            type: 'boolean',
+            role: 'media.mute',
+            def: false,
+            read: true,
+            write: true
+        },
+        native: {}
+    });
+}
+// Send a SOAP action to the TV. Resolves with the response body, or null on error.
+function upnpRequest(action, args) {
+    return new Promise((resolve) => {
+        const envelope = '<?xml version="1.0" encoding="utf-8"?>'
+            + '<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">'
+            + '<s:Body><u:' + action + ' xmlns:u="' + UPNP_SERVICE + '">' + args + '</u:' + action + '></s:Body>'
+            + '</s:Envelope>';
+        const req = http.request({
+            hostname: adapter.config.ipAddress,
+            port: UPNP_PORT,
+            path: UPNP_PATH,
+            method: 'POST',
+            timeout: 5000,
+            headers: {
+                'Content-Type': 'text/xml; charset="utf-8"',
+                'SOAPACTION': '"' + UPNP_SERVICE + '#' + action + '"',
+                'Content-Length': Buffer.byteLength(envelope)
+            }
+        }, function (res) {
+            let data = '';
+            res.on('data', function (chunk) { data += chunk; });
+            res.on('end', function () {
+                const error = data.match(/<errorCode>(\d+)<\/errorCode>/);
+                if (error) {
+                    if (error[1] === '401') {
+                        // the TV only answers clients on its own subnet
+                        adapter.log.warn('UPnP ' + action + ' refused (401 Unauthorized): the TV only accepts this from its own subnet, and ioBroker appears to be on a different one');
+                    } else {
+                        adapter.log.warn('UPnP ' + action + ' failed with upnp:' + error[1]);
+                    }
+                    resolve(null);
+                } else {
+                    resolve(data);
+                }
+            });
+        });
+        req.on('error', function (e) {
+            adapter.log.debug('UPnP ' + action + ' request failed: ' + e.message);
+            resolve(null);
+        });
+        req.on('timeout', function () {
+            req.destroy();
+            adapter.log.debug('UPnP ' + action + ' request timed out');
+            resolve(null);
+        });
+        req.end(envelope);
+    });
+}
+// Read volume and mute from the TV and store them as acknowledged states
+async function updateVolumeStates() {
+    const volume = await upnpRequest('GetVolume', UPNP_MASTER);
+    if (volume) {
+        const match = volume.match(/<CurrentVolume>(\d+)<\/CurrentVolume>/);
+        if (match) { adapter.setState('media.volume', parseInt(match[1], 10), true); }
+    }
+    const mute = await upnpRequest('GetMute', UPNP_MASTER);
+    if (mute) {
+        const match = mute.match(/<CurrentMute>([^<]+)<\/CurrentMute>/);
+        if (match) { adapter.setState('media.mute', match[1] === '1' || match[1] === 'true', true); }
+    }
+}
+async function setVolume(value) {
+    const volume = Math.round(parseFloat(value));
+    // the TV rejects anything outside 0-100 with upnp:402, so catch it here
+    if (isNaN(volume) || volume < 0 || volume > 100) {
+        adapter.log.warn('media.volume: ' + value + ' is not a level between 0 and 100, ignored');
+        await updateVolumeStates();
+        return;
+    }
+    const res = await upnpRequest('SetVolume', UPNP_MASTER + '<DesiredVolume>' + volume + '</DesiredVolume>');
+    if (res) { adapter.log.info('volume set to ' + volume); }
+    // read back, so the state reflects the TV even if the command was refused
+    await updateVolumeStates();
+}
+async function setMute(value) {
+    const res = await upnpRequest('SetMute', UPNP_MASTER + '<DesiredMute>' + (value ? 1 : 0) + '</DesiredMute>');
+    if (res) { adapter.log.info('mute set to ' + !!value); }
+    await updateVolumeStates();
 }


### PR DESCRIPTION
Implements #298 — volume/mute readback and absolute volume control.

## What this does

The remote control channel can only send `KEY_VOLUP` / `KEY_VOLDOWN` and never reports the
resulting level, so the volume can't be read and can't be set to an absolute value. These TVs also
expose a UPnP **RenderingControl** service on port 9197 supporting `GetVolume`, `SetVolume`,
`GetMute` and `SetMute`.

This adds two states:

| State | Type | Access |
|---|---|---|
| `media.volume` | number, 0–100, `level.volume` | read/write |
| `media.mute` | boolean, `media.mute` | read/write |

They're read on the existing polling interval and can be written to control the TV. Writes are
followed by a readback, so the state reflects the TV even if a command is refused.

* **No new dependency** — plain SOAP over `node:http`.
* **No pairing token involved** — port 9197 is independent of the WebSocket token.
* **Off by default**, behind a new `useUPnPVolume` option.
* **Reads skipped in standby** — port 9197 is closed when the TV is off.
* **Out-of-range writes are rejected before being sent** (the TV itself answers `upnp:402`).

## Important constraint: ioBroker must be on the TV's subnet

The TV answers the **control** endpoint only for clients on its own subnet. A client reaching it
through a router is refused with `401 Unauthorized`. The adapter logs a warning saying so, because
the symptom is otherwise very hard to diagnose.

This was established with a controlled experiment rather than inferred — same TV, same client
machine, same firmware, only the subnet changed:

| Client | Path | `GetVolume` |
|---|---|---|
| `192.168.11.53` | routed to TV on `192.168.123.117` | `401 Unauthorized` |
| `192.168.11.53` | same subnet, TV moved to `192.168.11.181` | **`Volume = 7`** |

No pairing, no token and no device-list change between those two measurements. The `401` is
purely about locality. Worth noting the same applies to the existing remote control channel: an
unpaired connection from a routed client is refused with an instant `ms.channel.timeOut` and no
on-screen prompt, while from the TV's own subnet it prompts and issues a token within seconds. So
this constraint is not new to this feature — it's just newly documented.

A read-only fallback exists if that's ever a problem: GENA `SUBSCRIBE` to
`/upnp/event/RenderingControl1` **is** accepted from a routed client (verified on both TVs, HTTP 200
plus a `NOTIFY` carrying the volume). It needs a long-lived subscription and an inbound callback
port the TV can reach, so it isn't the right default, but it's there.

## Testing

Verified on two 2024 sets — a **UE98DU9000UXXU** and a **UE43DU7100KXXU**: the reported level tracks
the physical remote (`100 → 99 → 98 → 97 → 96` on successive key presses), absolute sets apply
immediately, mute round-trips, and repeated rapid sets land on the final value. Also confirmed on
both models that port 9197 only starts listening when the TV powers on.

Checked against this repo's own toolchain — **no new lint errors**:

| Check | `master` baseline | This branch |
|---|---|---|
| `npx eslint .` | 1491 errors | **1491** |
| `npx eslint main.js` | 138 errors | **138** |
| `npm run test:package` | 0 passing (assertions commented out, see #7) | 0 passing |
| `npm run check` | 30 errors | 34 |

The 4 additional `npm run check` errors are `Property 'useUPnPVolume' / 'ipAddress' does not exist on
type 'AdapterConfig'`. Every pre-existing error of that kind has the same cause — there are no
`AdapterConfig` typings in the repo, so one appears for each config key. #300 adds them and clears
all of these; if that merges first this is moot, otherwise it needs one extra line there.

## One change outside the feature

`save()` in `admin/index.html` called `.val()` on every field, which returns `"on"` for a checkbox
regardless of its state — so the new option could not have been saved correctly. `load()` already
handled checkboxes; `save()` didn't. Fixed minimally.

## Not included

An option to apply a default volume when the TV switches on. It needs power-transition detection and
is a separate behaviour — happy to follow up once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
