### PR TITLE
Declare the adapter config type so npm run check can see it

### DIFF
--- a/lib/adapter-config.d.ts
+++ b/lib/adapter-config.d.ts
@@ -1,0 +1,31 @@
+// This file extends the AdapterConfig type from "@iobroker/types"
+// with the native settings declared in io-package.json.
+// Without it, every access to adapter.config.<option> is reported by
+// "npm run check" as "Property '<option>' does not exist on type 'AdapterConfig'".
+
+// Augment the globally declared type ioBroker.AdapterConfig
+declare global {
+    namespace ioBroker {
+        interface AdapterConfig {
+            /** wss or http */
+            protocol: string;
+            /** IP address of the TV */
+            ipAddress: string;
+            /** port of the remote control websocket */
+            port: string;
+            /** pairing token, "0" to deactivate */
+            token: string;
+            /** MAC address used for WakeOnLAN, "0" to deactivate */
+            macAddress: string;
+            /** delay in milliseconds between commands sent via control.sendCmd */
+            cmdDelay: string;
+            /** port polled to determine the power state */
+            pollingPort: string;
+            /** power state polling interval in seconds, "0" to deactivate */
+            pollingInterval: string;
+        }
+    }
+}
+
+// this is required so the above AdapterConfig is found by TypeScript / VSCode
+export {};

--- a/main.js
+++ b/main.js
@@ -83,7 +83,7 @@ function getPowerOnState(){
     });  
     setInterval(function(){
         (async () => {
-            let response = await isPortReachable(adapter.config.pollingPort, {host: adapter.config.ipAddress});
+            let response = await isPortReachable(parseFloat(adapter.config.pollingPort), {host: adapter.config.ipAddress});
             adapter.setState('powerOn', response, true, function (err) {
                 if (err) adapter.log.error(err);
             });
@@ -301,7 +301,7 @@ function startApp(app,x) {
         });
 };
 async function getPowerStateInstant(){
-            let response = await isPortReachable(adapter.config.pollingPort, {host: adapter.config.ipAddress});
+            let response = await isPortReachable(parseFloat(adapter.config.pollingPort), {host: adapter.config.ipAddress});
             adapter.setState('powerOn', response, true, function (err) {
                 if (err) adapter.log.error(err);
             });


### PR DESCRIPTION
## Problem

`npm run check` currently reports **40 errors**, and **19 of them** are the same thing:

```
main.js(267,34): error TS2339: Property 'cmdDelay' does not exist on type 'AdapterConfig'.
main.js(325,65): error TS2339: Property 'pollingPort' does not exist on type 'AdapterConfig'.
...
```

One for every native setting in `io-package.json` — `protocol`, `ipAddress`, `port`, `token`,
`macAddress`, `cmdDelay`, `pollingPort`, `pollingInterval` — because the `AdapterConfig` interface
is never declared anywhere in the repo.

`tsconfig.json` is already set up for this. It includes `**/*.d.ts` and even carries the comment
*"This is necessary for the automatic typing of the adapter config"* next to `resolveJsonModule`.
Only the declaration file itself was missing.

## Change

Adds `lib/adapter-config.d.ts` in the form generated by `@iobroker/create-adapter`, declaring the
eight native settings (all strings, as stored in `io-package.json`).

That also surfaced two argument mismatches the untyped config had been masking:

```js
await isPortReachable(adapter.config.pollingPort, {host: adapter.config.ipAddress});
```

`is-port-reachable` takes a `number`, and `pollingPort` was passed straight through as a string.
It works at runtime because Node accepts numeric strings, but it's inconsistent with
`pollingInterval` and `cmdDelay`, which the same file already wraps in `parseFloat`. Both call sites
now do the same.

## Result

| Check | Before | After |
|---|---|---|
| `npm run check` | 40 errors | **21 errors** |
| `npx eslint .` | 1491 errors | 1491 (unchanged) |
| `npm run test:package` | 0 passing (assertions commented out, #7) | 0 passing |

The remaining 21 are unrelated to the config — WebSocket payload typing (`data`, `event`, `split`,
`includes`), `setObject` overloads wanting explicit `read`/`write`, and a `log()` call passed an
`Error` instead of a string. Happy to look at those separately if useful, but they need real
decisions about the code rather than a declaration.

Groundwork towards #297 and the QA issues (#6, #7).

Note: if #299 is merged, its `useUPnPVolume` option should be added to this interface — one extra
line, and I'll follow up on whichever lands second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
