### PR TITLE
Sync engines in package-lock.json with package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "typescript": "~5.9.3"
       },
       "engines": {
-        "node": ">= 20"
+        "node": ">= 22"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {


### PR DESCRIPTION
b4dc095 ("Update from template: X0000-dropNode20") raised `engines.node` to `">= 22"` in
`package.json`, but didn't regenerate `package-lock.json` — which still declares `">= 20"`:

```json
// package.json
"engines": { "node": ">= 22" }

// package-lock.json  ->  packages[""].engines
"engines": { "node": ">= 20" }
```

That commit touched `.github/workflows/test-and-release.yml`, `README.md` and `package.json`, but
not the lockfile.

Regenerated with `npm install --package-lock-only`, which changes only that single line. `npm ci`
resolves cleanly against the result.

Harmless in practice, but it means the next `npm install` anyone runs produces an unrelated
one-line diff in their working tree — which is exactly how it turned up while I was preparing #299.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
