### PR TITLE
Do not leave installed-app message handlers on the shared socket

### DIFF
--- a/main.js
+++ b/main.js
@@ -256,7 +256,10 @@ function getApps(x) {
             })
         } if (!err) {
             ws.send(JSON.stringify({"method":"ms.channel.emit","params":{"event": "ed.installedApp.get", "to":"host"}}));
-            ws.on('message', function incoming(data) {
+            const onInstalledApps = function (data) {
+                // the socket is shared, so ignore anything that is not the reply we asked for
+                if (!data.includes('ed.installedApp.get')){ return; }
+                ws.removeListener('message', onInstalledApps);
                 data = JSON.parse(data);
                 for(let i = 0; i < data.data.data.length; i++){
                     adapter.setObject('apps.start_'+data.data.data[i].name, {
@@ -269,8 +272,9 @@ function getApps(x) {
                         native: {}
                     });
                 }
-                adapter.log.info('getInstalledApps successfully sent to tv')
-            })
+                adapter.log.info('getInstalledApps successfully sent to tv');
+            };
+            ws.on('message', onInstalledApps);
         };
 
     });
@@ -286,7 +290,9 @@ function startApp(app,x) {
             })
         } if (!err) {
             ws.send(JSON.stringify({"method":"ms.channel.emit","params":{"event": "ed.installedApp.get", "to":"host"}}));
-            ws.on('message', function incoming(data) {
+            const onInstalledApps = function (data) {
+                if (!data.includes('ed.installedApp.get')){ return; }
+                ws.removeListener('message', onInstalledApps);
                 data = JSON.parse(data);
                 if (data.event === 'ed.installedApp.get'){
                     for(let i = 0; i < data.data.data.length; i++){
@@ -296,7 +302,8 @@ function startApp(app,x) {
                         }
                     }
                 }
-            });
+            };
+            ws.on('message', onInstalledApps);
           }
         });
 };


### PR DESCRIPTION
## The bug

`getApps()` attaches a `'message'` handler every time it runs, never removes it, and — unlike
`startApp()` — doesn't check which message arrived:

```js
ws.on('message', function incoming(data) {
    data = JSON.parse(data);
    for(let i = 0; i < data.data.data.length; i++){
```

`wsConnect()` reuses an already-open socket, so that handler stays attached and receives **every
later message on that socket**. As soon as anything other than the `ed.installedApp.get` reply
arrives, `data.data.data` is undefined and it throws.

Handlers also accumulate — one per call — so after pressing `apps.getInstalledApps` three times the
reply is processed three times.

## Reproduction

Standalone repro of the handler pattern against a fake TV socket: request the app list, receive the
reply, then receive one unrelated message (`ms.channel.clientConnect`).

```
BEFORE (upstream master)
   apps handled : ["Netflix"]
   crashes      : Cannot read properties of undefined (reading 'length')
AFTER  (this PR)
   apps handled : ["Netflix"]
   crashes      : none
```

This may be behind #53 ("Problem to get the installed apps (and token)") — I can't confirm that
from here, but the failure mode matches: the app list works once, then the connection misbehaves
afterwards.

## The change

Both functions now use a named handler that ignores messages other than the reply it asked for and
detaches itself once it has handled it. The `data.includes(...)` guard follows the existing idiom in
`wsConnect()`, and works whether the payload is a string or a Buffer.

`startApp()` already had an event-name guard, so it never threw — but it leaked handlers the same
way, which made repeated launches re-run earlier handlers. Fixing only half of a two-line pattern
seemed worse than fixing both, hence both are included.

Behaviour is unchanged when the expected reply arrives.

## Checks

| Check | `master` baseline | This branch |
|---|---|---|
| `npx eslint .` | 1491 errors | **1489** |
| `npm run check` | 40 errors | 40 (unchanged) |
| `npm run test:package` | 0 passing (assertions commented out, #7) | 0 passing |

No lint error on any line this PR adds; the count drops by two because the replaced lines each
carried one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
